### PR TITLE
Readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [Django Events Foundation of North America (DEFNA)][DEFNA] is a 501(c)(3) non-profit based in California USA. It was formed in 2015 at the request of the [Django Software Foundation (DSF)][DSF] to run [DjangoCon US][]. 
 
-The DSF have licensed DEFNA to run DjangoCon US for 2015 to 2019. Beyond DjangoCon US, we also plan to be involved with other events in North America that cover the education and outreach of Django.
+The DSF have licensed DEFNA to run DjangoCon US from 2015 to 2022, with an agreement that automatically renews unless otherwise informed. Beyond DjangoCon US, we also plan to be involved with other events in North America that cover the education and outreach of Django.
 
 ## Foundation Details
 
@@ -10,19 +10,26 @@ The DSF have licensed DEFNA to run DjangoCon US for 2015 to 2019. Beyond DjangoC
 
 **Other names:** Django Events Foundation North America
 
-**Address:** 1320 Harbor Bay Parkway Ste 175, Alameda CA 94502-6589, U.S.A.
+**Address:** 3141 Stevens Creek Blvd #40102 San Jose, CA 95117, U.S.A.
 
 ## Current Board Members
 
-- Jeff Triplett, President (2015 to present)
-- Craig Bruce, Treasurer (2015 to present)
-- Stacey Haysler, Corporate Secretary (2015 to present)
-- Heather "Heats" Luna (2017 to present)
-- Kojo Idrissa (2017 to present)
-- Katherine "Kati" Michel (2017 to present)
+- Katia Lira, President (2018 to present)
+- Drew Winstel, Vice President (2021 to present)
+- Jen Myers, Treasurer (2021 to present)
+- Katherine "Kati" Michel, Corporate Secretary (2017 to present)
+- Adam Fast (2018 to present)
+- Carol Ganz (2021 to present)
+- Jeff Triplett (2015 to present)
+- Josue Balandrano Coronel (2018 to present)
 - Monique Murphy (2017 to present)
 
 ## Past Board Members
+
+- Craig Bruce (2015 to 2021)
+- Stacey Haysler (2015 to 2018)
+- Heather "Heats" Luna (2017 to 2018)
+- Kojo Idrissa (2017 to 2018)
 
 ## More Information
 

--- a/README.md
+++ b/README.md
@@ -14,15 +14,56 @@ The DSF have licensed DEFNA to run DjangoCon US from 2015 to 2022, with an agree
 
 ## Current Board Members
 
-- Katia Lira, President (2018 to present)
-- Drew Winstel, Vice President (2021 to present)
-- Jen Myers, Treasurer (2021 to present)
-- Katherine "Kati" Michel, Corporate Secretary (2017 to present)
+- Josue Balandrano Coronel (2018 to present)
 - Adam Fast (2018 to present)
 - Carol Ganz (2021 to present)
-- Jeff Triplett (2015 to present)
-- Josue Balandrano Coronel (2018 to present)
+- Katia Lira (2018 to present)
+- Katherine "Kati" Michel (2017 to present)
 - Monique Murphy (2017 to present)
+- Jen Myers (2021 to present)
+- Jeff Triplett (2015 to present)
+- Drew Winstel (2021 to present)
+
+### Officers
+
+#### 2021
+- Katia Lira, President
+- Drew Winstel, Vice President
+- Jen Myers, Treasurer
+- Katherine "Kati" Michel, Corporate Secretary
+
+#### 2020
+- Jeff Triplett, President
+- Katia Lira, Vice President
+- Monique Murphy, Treasurer
+- Katherine "Kati" Michel, Corporate Secretary
+
+#### 2019
+- Jeff Triplett, President
+- Katia Lira, Vice President [did she start 2019 or 2020?]
+- Craig Bruce, Treasurer
+- Adam Fast, Corporate Secretary
+
+#### 2018
+- Jeff Triplett, President
+- Craig Bruce, Treasurer
+- Adam Fast, Corporate Secretary
+
+#### 2017
+- Jeff Triplett, President
+- Craig Bruce, Treasurer
+- Stacey Haysler, Corporate Secretary
+
+#### 2016
+- Jeff Triplett, President
+- Craig Bruce, Treasurer
+- Stacey Haysler, Corporate Secretary
+
+#### 2015
+- Jeff Triplett, President
+- Craig Bruce, Treasurer
+- Stacey Haysler, Corporate Secretary
+
 
 ## Past Board Members
 

--- a/bylaws.md
+++ b/bylaws.md
@@ -1,0 +1,602 @@
+<center>
+#Bylaws
+
+#of
+
+#DJANGO EVENTS FOUNDATION NORTH AMERICA
+
+#A California Public Benefit Corporation
+</center>
+
+## ARTICLE 1 - OFFICES ##
+
+### SECTION 1. PRINCIPAL OFFICE ###
+
+The principal office of the corporation for the transaction of its business is located in Santa Clara County, California.
+
+### SECTION 2. CHANGE OF ADDRESS ###
+
+The county of the corporation’s principal office can be changed only by amendment of these bylaws and not otherwise. The board of directors may, however, change the principal office from one location to another within the named county by noting the changed address and effective date below, and such changes of address shall not be deemed an amendment of these bylaws.
+
+__________________	Dated: __________________
+
+__________________	Dated: __________________
+
+__________________	Dated: __________________
+
+### SECTION 3. OTHER OFFICES ###
+
+The corporation may also have offices at such other places, within or without the State of California, where it is qualified to do business, as its business may require and as the board of directors may, from time to time, designate.
+
+## ARTICLE 2 - PURPOSES ##
+
+### SECTION 1. OBJECTIVES AND PURPOSES ###
+
+The primary objectives and purposes of this corporation shall be: the provision of educational events for users of the Django software application.
+
+## ARTICLE 3 - DIRECTORS ##
+
+### SECTION 1. NUMBER ###
+
+The corporation shall have a minimum of three directors, and a maximum of nine directors, and collectively they shall be known as the board of directors. The number may be changed by amendment of this bylaw, or by repeal of this bylaw and adoption of a new bylaw, as provided in these bylaws.
+
+### SECTION 2. POWERS ###
+
+Subject to the provisions of the California Nonprofit Public Benefit Corporation law and any limitations in the articles of incorporation and bylaws relating to action required or permitted to be taken or approved by the members, if any, of this corporation, the activities and affairs of this corporation shall be conducted and all corporate powers shall be exercised by or under the direction of the board of directors.
+
+### SECTION 3. DUTIES ###
+
+It shall be the duty of the directors to:
+
+(a) Perform any and all duties imposed on them collectively or individually by law, by the articles of incorporation of this corporation, or by these bylaws;
+
+(b) Appoint and remove, employ and discharge, and, except as otherwise provided in these bylaws, prescribe the duties and fix the compensation, if any, of all officers, agents, and employees of the corporation;
+
+(c) Supervise all officers, agents, and employees of the corporation to assure that their duties are performed properly;
+
+(d) Meet at such times and places as required by these bylaws;
+
+(e) Register their addresses with the secretary of the corporation and notices of meetings mailed or telegraphed to them at such addresses shall be valid notices thereof.
+
+### SECTION 4. TERMS OF OFFICE ###
+
+Each director shall hold office until the next annual meeting for election of the board of directors as specified in these bylaws, and until his or her successor is elected and qualifies.
+
+### SECTION 5. COMPENSATION ###
+
+Directors shall serve without compensation except that they shall be allowed and paid reasonable travel costs for attendance at corporate meetings. In addition, they shall be allowed reasonable advancement or reimbursement of expenses incurred in the performance of their regular duties as specified in Section 3 of this Article. Directors may not be compensated for rendering services to the corporation in any capacity other than director unless such other compensation is reasonable and is allowable under the provisions of Section 6 of this Article. Any payments to directors shall be approved in advance in accordance with this corporation’s conflict of interest policy, as set forth in Article 9 of these bylaws.
+
+### SECTION 6. RESTRICTION REGARDING INTERESTED DIRECTORS ###
+
+Notwithstanding any other provision of these bylaws, not more than forty-nine percent (49%) of the persons serving on the board may be interested persons. For purposes of this Section, “interested persons” means either:
+
+(a) Any person currently being compensated by the corporation for services rendered it within the previous twelve (12) months, whether as a full- or part-time officer or other employee, independent contractor, or otherwise, excluding any reasonable compensation paid to a director as director; or
+
+(b) Any brother, sister, ancestor, descendant, spouse, brother-in-law, sister-in-law, son-in-law, daughter-in-law, mother-in-law, or father-in-law of any such person.
+
+### SECTION 7. PLACE OF MEETINGS ###
+
+Meetings shall be held at the principal office of the corporation unless otherwise provided by the board or at such place within or without the State of California which has been designated from time to time by resolution of the board of directors. In the absence of such designation, any meeting not held at the principal office of the corporation shall be valid only if held on the written consent of all directors given either before or after the meeting and filed with the secretary of the corporation or after all board members have been given written notice of the meeting as hereinafter provided for special meetings of the board. 
+
+Any meeting, regular or special, may be held by conference telephone, electronic video screen communication, or other communications equipment. Participation in a meeting through use of conference telephone constitutes presence in person at that meeting so long as all directors participating in the meeting are able to hear one another. Participation in a meeting through use of electronic video screen communication or other communications equipment (other than conference telephone) constitutes presence in person at that meeting if all of the following apply:
+
+a) Each director participating in the meeting can communicate with all of the other directors concurrently;
+
+b) Each director is provided the means of participating in all matters before the board, including, without limitation, the capacity to propose, or to interpose an objection to, a specific action to be taken by the corporation; and
+
+c) The corporation adopts and implements some means of verifying (1) that all persons participating in the meeting are directors of the corporation or are otherwise entitled to participate in the meeting, and (2) that all actions of, or votes by, the board are taken and cast only by directors and not by persons who are not directors. 
+
+### SECTION 8. REGULAR AND ANNUAL MEETINGS ###
+
+Regular meetings of directors shall be held on the first Wednesday of each month at 2:00 PM, unless such day falls on a legal holiday, in which event the regular meeting shall be held at the same hour and place on the next business day.
+
+If this corporation makes no provision for members, then, at the annual meeting of directors held on the first Wednesday of March, directors shall be elected by the board of directors in accordance with this section. Cumulative voting by directors for the election of directors shall not be permitted. The candidates receiving the highest number of votes up to the number of directors to be elected shall be elected. Each director shall cast one vote, with voting being by ballot only.
+
+### SECTION 9. SPECIAL MEETINGS ###
+
+Special meetings of the board of directors may be called by the chairperson of the board, the president, the vice president, the secretary, or by any two directors, and such meetings shall be held at the place, within or without the State of California, designated by the person or persons calling the meeting, and in the absence of such designation, at the principal office of the corporation.
+
+### SECTION 10. NOTICE OF MEETINGS ###
+
+Regular meetings of the board may be held without notice. Special meetings of the board shall be held upon four (4) days’ notice by first-class mail or forty-eight (48) hours’ notice delivered personally or by telephone or telegraph. If sent by mail or telegraph, the notice shall be deemed to be delivered on its deposit in the mails or on its delivery to the telegraph company. Such notices shall be addressed to each director at his or her address as shown on the books of the corporation. Notice of the time and place of holding an adjourned meeting need not be given to absent directors if the time and place of the adjourned meeting are fixed at the meeting adjourned and if such adjourned meeting is held no more than twenty-four (24) hours from the time of the original meeting. Notice shall be given of any adjourned regular or special meeting to directors absent from the original meeting if the adjourned meeting is held more than twenty-four (24) hours from the time of the original meeting.
+
+### SECTION 11. CONTENTS OF NOTICE ###
+
+Notice of meetings not herein dispensed with shall specify the place, day, and hour of the meeting. The purpose of any board meeting need not be specified in the notice.
+
+### SECTION 12. WAIVER OF NOTICE AND CONSENT TO HOLDING MEETINGS ###
+
+The transactions of any meeting of the board, however called and noticed or wherever held, are as valid as though the meeting had been duly held after proper call and notice, provided a quorum, as hereinafter defined, is present and provided that either before or after the meeting each director not present signs a waiver of notice, a consent to holding the meeting, or an approval of the minutes thereof. All such waivers, consents, or approvals shall be filed with the corporate records or made a part of the minutes of the meeting.
+
+### SECTION 13. QUORUM FOR MEETINGS ###
+
+A quorum shall consist of  a majority of active directors. 
+
+Except as otherwise provided in these bylaws or in the articles of incorporation of this corporation, or by law, no business shall be considered by the board at any meeting at which a quorum, as hereinafter defined, is not present, and the only motion which the chair shall entertain at such meeting is a motion to adjourn. However, a majority of the directors present at such meeting may adjourn from time to time until the time fixed for the next regular meeting of the board. 
+
+When a meeting is adjourned for lack of a quorum, it shall not be necessary to give any notice of the time and place of the adjourned meeting or of the business to be transacted at such meeting, other than by announcement at the meeting at which the adjournment is taken, except as provided in Section 10 of this Article.
+
+The directors present at a duly called and held meeting at which a quorum is initially present may continue to do business notwithstanding the loss of a quorum at the meeting due to a withdrawal of directors from the meeting, provided that any action thereafter taken must be approved by at least a majority of the required quorum for such meeting or such greater percentage as may be required by law, or the articles of incorporation or bylaws of this corporation.
+
+### SECTION 14. MAJORITY ACTION AS BOARD ACTION ###
+
+Every act or decision done or made by a majority of the directors present at a meeting duly held at which a quorum is present is the act of the board of directors, unless the articles of incorporation or bylaws of this corporation, or provisions of the California Nonprofit Public Benefit Corporation Law, particularly those provisions relating to appointment of committees (Section 5212), approval of contracts or transactions in which a director has a material financial interest (Section 5233), and indemnification of directors (Section 5238e), require a greater percentage or different voting rules for approval of a matter by the board.
+
+In the event of an even vote, where the Board votes do not result in a majority, the matter will be immediately put to a second vote. If that second vote does not result in a majority, the President, Secretary, and Treasurer will vote on the matter, with the majority of that vote deciding the issue.
+
+### SECTION 15. CONDUCT OF MEETINGS ###
+
+Meetings of the board of directors shall be presided over by the chairperson of the board, or, if no such person has been so designated or, in his or her absence, the president of the corporation or, in his or her absence, by the vice president of the corporation or, in the absence of each of these persons, by a chairperson chosen by a majority of the directors present at the meeting. The secretary of the corporation shall act as secretary of all meetings of the board, provided that, in his or her absence, the presiding officer shall appoint another person to act as secretary of the meeting.
+
+Meetings shall be governed by Roberts Rules of Order, as such rules may be revised from time to time, insofar as such rules are not inconsistent with or in conflict with these bylaws, with the articles of incorporation of this corporation, or with provisions of law.
+
+### SECTION 16. ACTION BY UNANIMOUS WRITTEN CONSENT WITHOUT MEETING ###
+
+Any action required or permitted to be taken by the board of directors under any provision of law may be taken without a meeting, if all members of the board shall individually or collectively consent in writing to such action. For the purposes of this Section only, “all members of the board” shall not include any “interested director” as defined in Section 5233 of the California Nonprofit Public Benefit Corporation Law. Such written consent or consents shall be filed with the minutes of the proceedings of the board. Such action by written consent shall have the same force and effect as the unanimous vote of the directors. Any certificate or other document filed under any provision of law which relates to action so taken shall state that the action was taken by unanimous written consent of the board of directors without a meeting and that the bylaws of this corporation authorize the directors to so act, and such statement shall be prima facie evidence of such authority.
+
+### SECTION 17. VACANCIES ###
+
+Vacancies on the board of directors shall exist (1) on the death, resignation, or removal of any director, and (2) whenever the number of authorized directors is increased.
+
+The board of directors may declare vacant the office of a director who has been declared of unsound mind by a final order of court, or convicted of a felony, or been found by a final order or judgment of any court to have breached any duty under Section 5230 and following of the California Nonprofit Public Benefit Corporation Law.
+
+If this corporation has any members, then, if the corporation has fewer than fifty (50) members, directors may be removed without cause by a majority of all members, or, if the corporation has fifty (50) or more members, by vote of a majority of the votes represented at a membership meeting at which a quorum is present. 
+
+If this corporation has no members, directors may be removed without cause by a majority of the directors then in office.
+
+Any director may resign effective upon giving written notice to the chairperson of the board, the president, the secretary, or the board of directors, unless the notice specifies a later time for the effectiveness of such resignation. No director may resign if the corporation would then be left without a duly elected director or directors in charge of its affairs, except upon notice to the attorney general.
+
+Vacancies on the board may be filled by approval of the board or, if the number of directors then in office is less than a quorum, by (1) the unanimous written consent of the directors then in office, (2) the affirmative vote of a majority of the directors then in office at a meeting held pursuant to notice or waivers of notice complying with this Article of these bylaws, or (3) a sole remaining director. If this corporation has members, however, vacancies created by the removal of a director may be filled only by the approval of the members. The members, if any, of this corporation may elect a director at any time to fill any vacancy not filled by the directors.
+
+A person elected to fill a vacancy as provided by this Section shall hold office until the next annual election of the board of directors or until his or her death, resignation, or removal from office.
+
+### SECTION 18. NONLIABILITY OF DIRECTORS ###
+
+The directors shall not be personally liable for the debts, liabilities, or other obligations of the corporation.
+
+### SECTION 19. INDEMNIFICATION BY CORPORATION OF DIRECTORS, OFFICERS, EMPLOYEES, AND OTHER AGENTS ###
+
+To the extent that a person who is, or was, a director, officer, employee, or other agent of this corporation has been successful on the merits in defense of any civil, criminal, administrative, or investigative proceeding brought to procure a judgment against such person by reason of the fact that he or she is, or was, an agent of the corporation, or has been successful in defense of any claim, issue, or matter, therein, such person shall be indemnified against expenses actually and reasonably incurred by the person in connection with such proceeding.
+
+If such person either settles any such claim or sustains a judgment against him or her, then indemnification against expenses, judgments, fines, settlements, and other amounts reasonably incurred in connection with such proceedings shall be provided by this corporation but only to the extent allowed by, and in accordance with the requirements of, Section 5238 of the California Nonprofit Public Benefit Corporation Law.
+
+### SECTION 20. INSURANCE FOR CORPORATE AGENTS ###
+
+The board of directors may adopt a resolution authorizing the purchase and maintenance of insurance on behalf of any agent of the corporation (including a director, officer, employee, or other agent of the corporation) against any liability other than for violating provisions of law relating to self-dealing (Section 5233 of the California Nonprofit Public Benefit Corporation Law) asserted against or incurred by the agent in such capacity or arising out of the agent’s status as such, whether or not the corporation would have the power to indemnify the agent against such liability under the provisions of Section 5238 of the California Nonprofit Public Benefit Corporation Law.
+
+## ARTICLE 4 - OFFICERS ##
+
+### SECTION 1. NUMBER OF OFFICERS ###
+
+The officers of the corporation shall be a president, a secretary, and a chief financial officer who shall be designated the treasurer. The corporation may also have, as determined by the board of directors, a chairperson of the board, one or more vice presidents, assistant secretaries, assistant treasurers, or other officers. Any number of offices may be held by the same person except that neither the secretary nor the treasurer may serve as the president or chairperson of the board.
+
+### SECTION 2. QUALIFICATION, ELECTION, AND TERM OF OFFICE ###
+
+Any person may serve as an officer of this corporation. Officers shall be elected by the board of directors, at any time, and each officer shall hold office until he or she resigns, is removed, or is otherwise disqualified to serve, or until his or her successor shall be elected and qualified, whichever occurs first.
+
+### SECTION 3. SUBORDINATE OFFICERS ###
+
+The board of directors may appoint such other officers or agents as it may deem desirable, and such officers shall serve such terms, have such authority, and perform such duties as may be prescribed from time to time by the board of directors.
+
+### SECTION 4. REMOVAL AND RESIGNATION ###
+
+Any officer may be removed, either with or without cause, by the board of directors, at any time. Any officer may resign at any time by giving written notice to the board of directors or to the president or secretary of the corporation. Any such resignation shall take effect at the date of receipt of such notice or at any later date specified therein, and, unless otherwise specified therein, the acceptance of such resignation shall not be necessary to make it effective. The above provisions of this Section shall be superseded by any conflicting terms of a contract which has been approved or ratified by the board of directors relating to the employment of any officer of the corporation.
+
+### SECTION 5. VACANCIES ###
+
+Any vacancy caused by the death, resignation, removal, disqualification, or otherwise, of any officer shall be filled by the board of directors. In the event of a vacancy in any office other than that of president, such vacancy may be filled temporarily by appointment by the president until such time as the board shall fill the vacancy. Vacancies occurring in offices of officers appointed at the discretion of the board may or may not be filled as the board shall determine.
+
+### SECTION 6. DUTIES OF PRESIDENT ###
+
+The president shall be the chief executive officer of the corporation and shall, subject to the control of the board of directors, supervise and control the affairs of the corporation and the activities of the officers. He or she shall perform all duties incident to his or her office and such other duties as may be required by law, by the articles of incorporation of this corporation, or by these bylaws, or which may be prescribed from time to time by the board of directors. Unless another person is specifically appointed as chairperson of the board of directors, he or she shall preside at all meetings of the board of directors. If applicable, the president shall preside at all meetings of the members. Except as otherwise expressly provided by law, by the articles of incorporation, or by these bylaws, he or she shall, in the name of the corporation, execute such deeds, mortgages, bonds, contracts, checks, or other instruments which may from time to time be authorized by the board of directors.
+
+### SECTION 7. DUTIES OF VICE PRESIDENT ###
+
+In the absence of the president, or in the event of his or her inability or refusal to act, the vice president shall perform all the duties of the president, and when so acting shall have all the powers of, and be subject to all the restrictions on, the president. The vice president shall have other powers and perform such other duties as may be prescribed by law, by the articles of incorporation, or by these bylaws, or as may be prescribed by the board of directors.
+
+### SECTION 8. DUTIES OF SECRETARY ###
+
+The secretary shall:
+
+Certify and keep at the principal office of the corporation the original, or a copy of these bylaws as amended or otherwise altered to date.
+
+Keep at the principal office of the corporation or at such other place as the board may determine, a book of minutes of all meetings of the directors, and, if applicable, meetings of committees of directors and of members, recording therein the time and place of holding, whether regular or special, how called, how notice thereof was given, the names of those present or represented at the meeting, and the proceedings thereof.
+
+Ensure that the minutes of meetings of the corporation, any written consents approving action taken without a meeting, and any supporting documents pertaining to meetings, minutes, and consents shall be contemporaneously recorded in the corporate records of this corporation. “Contemporaneously” in this context means that the minutes, consents, and supporting documents shall be recorded in the records of this corporation by the later of (1) the next meeting of the board, committee, membership, or other body for which the minutes, consents, or supporting documents are being recorded, or (2) sixty (60) days after the date of the meeting or written consent.
+
+See that all notices are duly given in accordance with the provisions of these bylaws or as required by law.
+
+Be custodian of the records and of the seal of the corporation and see that the seal is affixed to all duly executed documents, the execution of which on behalf of the corporation under its seal is authorized by law or these bylaws.
+
+Keep at the principal office of the corporation a membership book containing the name and address of each and any member, and, in the case where any membership has been terminated, the secretary shall record such fact in the membership book together with the date on which such membership ceased.
+
+Exhibit at all reasonable times to any director of the corporation, or to his or her agent or attorney, on request therefore, the bylaws, the membership book, and the minutes of the proceedings of the directors of the corporation.
+
+In general, perform all duties incident to the office of secretary and such other duties as may be required by law, by the articles of incorporation of this corporation, or by these bylaws, or which may be assigned to him or her from time to time by the board of directors.
+
+### SECTION 9. DUTIES OF TREASURER ###
+
+Subject to the provisions of these bylaws relating to the “Execution of Instruments, Deposits, and Funds,” the treasurer shall:
+
+Have charge and custody of, and be responsible for, all funds and securities of the corporation, and deposit all such funds in the name of the corporation in such banks, trust companies, or other depositories as shall be selected by the board of directors.
+
+Receive, and give receipt for, monies due and payable to the corporation from any source whatsoever.
+
+Disburse, or cause to be disbursed, the funds of the corporation as may be directed by the board of directors, taking proper vouchers for such disbursements.
+
+Keep and maintain adequate and correct accounts of the corporation’s properties and business transactions, including accounts of its assets, liabilities, receipts, disbursements, gains, and losses.
+
+Exhibit at all reasonable times the books of account and financial records to any director of the corporation, or to his or her agent or attorney, on request therefor.
+
+Render to the president and directors, whenever requested, an account of any or all of his or her transactions as treasurer and of the financial condition of the corporation. 
+
+Prepare, or cause to be prepared, and certify, or cause to be certified, the financial statements to be included in any required reports.
+
+In general, perform all duties incident to the office of treasurer and such other duties as may be required by law, by the articles of incorporation of the corporation, or by these bylaws, or which may be assigned to him or her from time to time by the board of directors.
+
+
+
+### SECTION 10. COMPENSATION ###
+
+The salaries of the officers, if any, shall be fixed from time to time by resolution of the board of directors, and no officer shall be prevented from receiving such salary by reason of the fact that he or she is also a director of the corporation, provided, however, that such compensation paid a director for serving as an officer of this corporation shall only be allowed if permitted under the provisions of Article 3, Section 6, of these bylaws. In all cases, any salaries received by officers of this corporation shall be reasonable and given in return for services actually rendered for the corporation which relate to the performance of the charitable or public purposes of this corporation. All officer salaries shall be approved in advance in accordance with this corporation’s conflict of interest policy, as set forth in Article 9 of these bylaws.
+
+## ARTICLE 5 - COMMITTEES ##
+
+### SECTION 1. EXECUTIVE COMMITTEE ###
+
+The board of directors may, by a majority vote of directors, designate two (2) or more of its members (who may also be serving as officers of this corporation) to constitute an executive committee of the board and delegate to such committee any of the powers and authority of the board in the management of the business and affairs of the corporation, except with respect to:
+
+(a) The approval of any action which, under law or the provisions of these bylaws, requires the approval of the members or of a majority of all of the members.
+
+(b) The filling of vacancies on the board or on any committee that has the authority of the board. 
+
+(c) The fixing of compensation of the directors for serving on the board or on any committee.
+
+(d) The amendment or repeal of bylaws or the adoption of new bylaws.
+
+(e) The amendment or repeal or any resolution of the board which by its express terms is not so amendable or repealable.
+
+(f) The appointment of committees of the board or the members thereof.
+
+(g) The expenditure of corporate funds to support a nominee for director after there are more people nominated for director than can be elected.
+
+(h) The approval of any transaction to which this corporation is a party and in which one or more of the directors has a material financial interest, except as expressly provided in Section 5233(d)(3) of the California Nonprofit Public Benefit Corporation Law.
+
+By a majority vote of its members then in office, the board may at any time revoke or modify any or all of the authority so delegated, increase or decrease but not below two (2) the number of its members, and fill vacancies therein from the members of the board. The committee shall keep regular minutes of its proceedings, cause them to be filed with the corporate records, and report the same to the board from time to time as the board may require. 
+
+### SECTION 2. OTHER COMMITTEES ###
+
+The corporation shall have such other committees as may from time to time be designated by resolution of the board of directors. Such other committees may consist of persons who are not also members of the board. These additional committees shall act in an advisory capacity only to the board and shall be clearly titled as “advisory” committees.
+
+### SECTION 3. MEETINGS AND ACTION OF COMMITTEES ###
+
+Meetings and action of committees shall be governed by, noticed, held, and taken in accordance with the provisions of these bylaws concerning meetings of the board of directors, with such changes in the context of such bylaw provisions as are necessary to substitute the committee and its members for the board of directors and its members, except that the time for regular meetings of committees may be fixed by resolution of the board of directors or by the committee. The time for special meetings of committees may also be fixed by the board of directors. The board of directors may also adopt rules and regulations pertaining to the conduct of meetings of committees to the extent that such rules and regulations are not inconsistent with the provisions of these bylaws.
+
+
+
+## ARTICLE 6 - EXECUTION OF INSTRUMENTS, DEPOSITS, AND FUNDS ##
+
+### SECTION 1. EXECUTION OF INSTRUMENTS ###
+
+The board of directors, except as otherwise provided in these bylaws, may by resolution authorize any officer or agent of the corporation to enter into any contract or execute and deliver any instrument in the name of and on behalf of the corporation, and such authority may be general or confined to specific instances. Unless so authorized, no officer, agent, or employee shall have any power or authority to bind the corporation by any contract or engagement or to pledge its credit or to render it liable monetarily for any purpose or in any amount.
+
+### SECTION 2. CHECKS AND NOTES ###
+
+Except as otherwise specifically determined by resolution of the board of directors, or as otherwise required by law, checks, drafts, promissory notes, orders for the payment of money, and other evidence of indebtedness of the corporation shall be signed by the treasurer and countersigned by the president of the corporation.
+
+### SECTION 3. DEPOSITS ###
+
+All funds of the corporation shall be deposited from time to time to the credit of the corporation in such banks, trust companies, or other depositories as the board of directors may select.
+
+### SECTION 4. GIFTS ###
+
+The board of directors may accept on behalf of the corporation any contribution, gift, bequest, or devise for the charitable or public purposes of this corporation.
+
+## ARTICLE 7 - CORPORATE RECORDS, REPORTS, AND SEAL ##
+
+### SECTION 1. MAINTENANCE OF CORPORATE RECORDS ###
+
+The corporation shall keep at its principal office in the State of California:
+
+(a) Minutes of all meetings of directors, committees of the board, and, if this corporation has members, of all meetings of members, indicating the time and place of holding such meetings, whether regular or special, how called, the notice given, and the names of those present and the proceedings thereof;
+
+(b) Adequate and correct books and records of account, including accounts of its properties and business transactions and accounts of its assets, liabilities, receipts, disbursements, gains, and losses;
+
+(c) A record of its members, if any, indicating their names and addresses and, if applicable, the class of membership held by each member and the termination date of any membership;
+
+(d) A copy of the corporation’s articles of incorporation and bylaws as amended to date, which shall be open to inspection by the members, if any, of the corporation at all reasonable times during office hours.
+
+### SECTION 2. CORPORATE SEAL ###
+
+The board of directors may adopt, use, and at will alter, a corporate seal. Such seal shall be kept at the principal office of the corporation. Failure to affix the seal to corporate instruments, however, shall not affect the validity of any such instrument.
+
+### SECTION 3. DIRECTORS’ INSPECTION RIGHTS ###
+
+Every director shall have the absolute right at any reasonable time to inspect and copy all books, records, and documents of every kind and to inspect the physical properties of the corporation.
+
+### SECTION 4. MEMBERS’ INSPECTION RIGHTS ###
+
+If this corporation has any members, then each and every member shall have the following inspection rights, for a purpose reasonably related to such person’s interest as a member:
+
+(a) To inspect and copy the record of all members’ names, addresses, and voting rights, at reasonable times, upon five (5) business days’ prior written demand on the corporation, which demand shall state the purpose for which the inspection rights are requested.
+
+(b) To obtain from the secretary of the corporation, upon written demand and payment of a reasonable charge, an alphabetized list of the names, addresses, and voting rights of those members entitled to vote for the election of directors as of the most recent record date for which the list has been compiled or as of the date specified by the member subsequent to the date of demand. The demand shall state the purpose for which the list is requested. The membership list shall be made available on or before the later of ten (10) business days after the demand is received or after the date specified therein as of which the list is to be compiled. 
+
+(c) To inspect at any reasonable time the books, records, or minutes of proceedings of the members or of the board or committees of the board, upon written demand on the corporation by the member, for a purpose reasonably related to such person’s interests as a member.
+
+### SECTION 5. RIGHT TO COPY AND MAKE EXTRACTS ###
+
+Any inspection under the provisions of this Article may be made in person or by agent or attorney and the right to inspection includes the right to copy and make extracts.
+
+### SECTION 6. ANNUAL REPORT ###
+
+The board shall cause an annual report to be furnished not later than one hundred and twenty (120) days after the close of the corporation’s fiscal year to all directors of the corporation and, if this corporation has members, to any member who requests it in writing, which report shall contain the following information in appropriate detail:
+
+(a) The assets and liabilities, including the trust funds, of the corporation as of the end of the fiscal year;
+
+(b) The principal changes in assets and liabilities, including trust funds, during the fiscal year;
+
+(c) The revenue or receipts of the corporation, both unrestricted and restricted to particular purposes, for the fiscal year;
+
+(d) The expenses or disbursements of the corporation, for both general and restricted purposes, during the fiscal year;
+
+(e) Any information required by Section 7 of this Article.
+
+The annual report shall be accompanied by any report thereon of independent accountants, or, if there is no such report, the certificate of an authorized officer of the corporation that such statements were prepared without audit from the books and records of the corporation.
+
+If this corporation has members, then, if this corporation receives Twenty-Five Thousand Dollars ($25,000), or more, in gross revenues or receipts during the fiscal year, this corporation shall automatically send the above annual report to all members, in such manner, at such time, and with such contents, including an accompanying report from independent accountants or certification of a corporate officer, as specified by the above provisions of this Section relating to the annual report.
+
+### SECTION 7. ANNUAL STATEMENT OF SPECIFIC TRANSACTIONS TO MEMBERS ###
+
+This corporation shall mail or deliver to all directors and any and all members a statement within one hundred and twenty (120) days after the close of its fiscal year which briefly describes the amount and circumstances of any indemnification or transaction of the following kind:
+
+Any transaction in which the corporation, or its parent or its subsidiary, was a party, and in which either of the following had a direct or indirect material financial interest:
+
+(a) Any director or officer of the corporation, or its parent or its subsidiary (a mere common directorship shall not be considered a material financial interest); or
+
+(b) Any holder of more than ten percent (10%) of the voting power of the corporation, its parent, or its subsidiary.
+
+The above statement need only be provided with respect to a transaction during the previous fiscal year involving more than Fifty Thousand Dollars ($50,000) or which was one of a number of transactions with the same persons involving, in the aggregate, more than Fifty Thousand Dollars ($50,000).
+
+Similarly, the statement need only be provided with respect to indemnifications or advances aggregating more than Ten Thousand Dollars ($10,000) paid during the previous fiscal year to any director or officer, except that no such statement need be made if such indemnification was approved by the members pursuant to Section 5238(e)(2) of the California Nonprofit Public Benefit Corporation Law.
+
+Any statement required by this Section shall briefly describe the names of the interested persons involved in such transactions, stating each person’s relationship to the corporation, the nature of such person’s interest in the transaction, and, where practical, the amount of such interest, provided that in the case of a transaction with a partnership of which such person is a partner, only the interest of the partnership need be stated. 
+
+If this corporation has any members and provides all members with an annual report according to the provisions of Section 6 of this Article, then such annual report shall include the information required by this Section.
+
+## ARTICLE 8 - FISCAL YEAR ##
+
+### SECTION 1. FISCAL YEAR OF THE CORPORATION ###
+
+The fiscal year of the corporation shall begin on January 1 and end on December 31 in each year.
+
+## ARTICLE 9 - CONFLICT OF INTEREST AND COMPENSATION APPROVAL POLICIES ##
+
+### SECTION 1. PURPOSE OF CONFLICT OF INTEREST POLICY ###
+
+The purpose of this conflict of interest policy is to protect this tax-exempt corporation’s interest when it is contemplating entering into a transaction or arrangement that might benefit the private interest of an officer or director of the corporation or any “disqualified person” as defined in Section 4958(f)(1) of the Internal Revenue Code and as amplified by Section 53.4958-3 of the IRS Regulations and which might result in a possible “excess benefit transaction” as defined in Section 4958(c)(1)(A) of the Internal Revenue Code and as amplified by Section 53.4958 of the IRS Regulations. This policy is intended to supplement but not replace any applicable state and federal laws governing conflict of interest applicable to nonprofit and charitable organizations.
+
+### SECTION 2. DEFINITIONS ###
+
+(a) <span style="text-decoration:underline;">Interested Person.</span> 
+
+Any director, principal officer, member of a committee with governing board delegated powers, or any other person who is a “disqualified person” as defined in Section 4958(f)(1) of the Internal Revenue Code and as amplified by Section 53.4958-3 of the IRS Regulations, who has a direct or indirect financial interest, as defined below, is an interested person.
+
+(b) <span style="text-decoration:underline;">Financial Interest.</span> 
+
+A person has a financial interest if the person has, directly or indirectly, through business, investment, or family:
+
+
+    (1) an ownership or investment interest in any entity with which the corporation has a transaction or arrangement,
+
+
+    (2) a compensation arrangement with the corporation or with any entity or individual with which the corporation has a transaction or arrangement, or
+
+
+    (3) a potential ownership or investment interest in, or compensation arrangement with, any entity or individual with which the corporation is negotiating a transaction or arrangement.
+
+Compensation includes direct and indirect remuneration as well as gifts or favors that are not insubstantial.
+
+A financial interest is not necessarily a conflict of interest. Under Section 3, paragraph b, a person who has a financial interest may have a conflict of interest only if the appropriate governing board or committee decides that a conflict of interest exists.
+
+### SECTION 3. CONFLICT OF INTEREST AVOIDANCE PRODEDURES ###
+
+(a) <span style="text-decoration:underline;">Duty to Disclose. </span>
+
+In connection with any actual or possible conflict of interest, an interested person must disclose the existence of the financial interest and be given the opportunity to disclose all material facts to the directors and members of committees with governing board delegated powers considering the proposed transaction or arrangement.
+
+(b) <span style="text-decoration:underline;">Determining Whether a Conflict of Interest Exists. </span>
+
+After disclosure of the financial interest and all material facts, and after any discussion with the interested person, he/she shall leave the governing board or committee meeting while the determination of a conflict of interest is discussed and voted upon. The remaining board or committee members shall decide if a conflict of interest exists.
+
+(c) <span style="text-decoration:underline;">Procedures for Addressing the Conflict of Interest. </span>
+
+An interested person may make a presentation at the governing board or committee meeting, but after the presentation, he/she shall leave the meeting during the discussion of, and the vote on, the transaction or arrangement involving the possible conflict of interest.
+
+The chairperson of the governing board or committee shall, if appropriate, appoint a disinterested person or committee to investigate alternatives to the proposed transaction or arrangement.
+
+After exercising due diligence, the governing board or committee shall determine whether the corporation can obtain with reasonable efforts a more advantageous transaction or arrangement from a person or entity that would not give rise to a conflict of interest.
+
+If a more advantageous transaction or arrangement is not reasonably possible under circumstances not producing a conflict of interest, the governing board or committee shall determine by a majority vote of the disinterested directors whether the transaction or arrangement is in the corporation’s best interest, for its own benefit, and whether it is fair and reasonable. In conformity with the above determination, it shall make its decision as to whether to enter into the transaction or arrangement.
+
+(d) <span style="text-decoration:underline;">Violations of the Conflicts of Interest Policy. </span>
+
+If the governing board or committee has reasonable cause to believe a member has failed to disclose actual or possible conflicts of interest, it shall inform the member of the basis for such belief and afford the member an opportunity to explain the alleged failure to disclose.
+
+If, after hearing the member’s response and after making further investigation as warranted by the circumstances, the governing board or committee determines the member has failed to disclose an actual or possible conflict of interest, it shall take appropriate disciplinary and corrective action.
+
+### SECTION 4. RECORDS OF BOARD AND BOARD COMMITTEE PROCEEDINGS ###
+
+The minutes of meetings of the governing board and all committees with board delegated powers shall contain:
+
+(a) The names of the persons who disclosed or otherwise were found to have a financial interest in connection with an actual or possible conflict of interest, the nature of the financial interest, any action taken to determine whether a conflict of interest was present, and the governing board’s or committee’s decision as to whether a conflict of interest in fact existed.
+
+(b) The names of the persons who were present for discussions and votes relating to the transaction or arrangement, the content of the discussion, including any alternatives to the proposed transaction or arrangement, and a record of any votes taken in connection with the proceedings.
+
+### SECTION 5. COMPENSATION APPROVAL POLICIES ###
+
+A voting member of the governing board who receives compensation, directly or indirectly, from the corporation for services is precluded from voting on matters pertaining to that member’s compensation.
+
+A voting member of any committee whose jurisdiction includes compensation matters and who receives compensation, directly or indirectly, from the corporation for services is precluded from voting on matters pertaining to that member’s compensation.
+
+No voting member of the governing board or any committee whose jurisdiction includes compensation matters and who receives compensation, directly or indirectly, from the corporation, either individually or collectively, is prohibited from providing information to any committee regarding compensation.
+
+When approving compensation for directors, officers and employees, contractors, and any other compensation contract or arrangement, in addition to complying with the conflict of interest requirements and policies contained in the preceding and following sections of this article as well as the preceding paragraphs of this section of this article, the board or a duly constituted compensation committee of the board shall also comply with the following additional requirements and procedures:
+
+(a) The terms of compensation shall be approved by the board or compensation committee prior to the first payment of compensation.
+
+(b) All members of the board or compensation committee who approve compensation arrangements must not have a conflict of interest with respect to the compensation arrangement as specified in IRS Regulation Section 53.4958-6(c)(iii), which generally requires that each board member or committee member approving a compensation arrangement between this organization and a “disqualified person” (as defined in Section 4958(f)(1) of the Internal Revenue Code and as amplified by Section 53.4958-3 of the IRS Regulations):
+
+
+        1. is not the person who is the subject of compensation arrangement, or a family member of such person;
+
+
+        2. is not in an employment relationship subject to the direction or control of the person who is the subject of compensation arrangement
+
+
+        3. does not receive compensation or other payments subject to approval by the person who is the subject of compensation arrangement 
+
+
+        4. has no material financial interest affected by the compensation arrangement; and
+
+
+        5. does not approve a transaction providing economic benefits to the person who is the subject of the compensation arrangement, who in turn has approved or will approve a transaction providing benefits to the board or committee member.
+
+
+    (c) The board or compensation committee shall obtain and rely upon appropriate data as to comparability prior to approving the terms of compensation. Appropriate data may include the following:
+
+
+        1. compensation levels paid by similarly situated organizations, both taxable and tax-exempt, for functionally comparable positions. “Similarly situated” organizations are those of a similar size and purpose and with similar resources
+
+
+        2. the availability of similar services in the geographic area of this organization
+
+
+        3. current compensation surveys compiled by independent firms
+
+
+        4. actual written offers from similar institutions competing for the services of the person who is the subject of the compensation arrangement.
+
+
+    As allowed by IRS Regulation 4958-6, if this organization has average annual gross receipts (including contributions) for its three prior tax years of less than $1 million, the board or compensation committee will have obtained and relied upon appropriate data as to comparability if it obtains and relies upon data on compensation paid by three comparable organizations in the same or similar communities for similar services.
+
+
+    (d) The terms of compensation and the basis for approving them shall be recorded in written minutes of the meeting of the board or compensation committee that approved the compensation. Such documentation shall include: 
+
+
+        1. the terms of the compensation arrangement and the date it was approved
+
+
+        2. the members of the board or compensation committee who were present during debate on the transaction, those who voted on it, and the votes cast by each board or committee member
+
+
+        3. the comparability data obtained and relied upon and how the data was obtained
+
+
+        4. the board or compensation committee determines that reasonable compensation for a specific position in this organization or for providing services under any other compensation arrangement with this organization is higher or lower than the range of comparability data obtained, the board or committee shall record in the minutes of the meeting the basis for its determination
+
+
+        5. the board or committee makes adjustments to comparability data due to geographic area or other specific conditions, these adjustments and the reasons for them shall be recorded in the minutes of the board or committee meeting
+
+
+        6. any actions taken with respect to determining if a board or committee member had a conflict of interest with respect to the compensation arrangement, and if so, actions taken to make sure the member with the conflict of interest did not affect or participate in the approval of the transaction (for example, a notation in the records that after a finding of conflict of interest by a member, the member with the conflict of interest was asked to, and did, leave the meeting prior to a discussion of the compensation arrangement and a taking of the votes to approve the arrangement).
+
+The minutes of board or committee meetings at which compensation arrangements are approved must be prepared before the later of the date of the next board or committee meeting or 60 days after the final actions of the board or committee are taken with respect to the approval of the compensation arrangements. The minutes must be reviewed and approved by the board and committee as reasonable, accurate, and complete within a reasonable period thereafter, normally prior to or at the next board or committee meeting following final action on the arrangement by the board or committee. 
+
+### SECTION 6. ANNUAL STATEMENTS ###
+
+Each director, principal officer, and member of a committee with governing board delegated powers shall annually sign a statement which affirms such person:
+
+
+    (a) has received a copy of the conflicts of interest policy,
+
+
+    (b) has read and understands the policy,
+
+
+    (c) has agreed to comply with the policy, and
+
+
+    (d) understands the corporation is charitable and in order to maintain its federal tax exemption it must engage primarily in activities which accomplish one or more of its tax-exempt purposes.
+
+### SECTION 7. PERIODIC REVIEWS ###
+
+To ensure the corporation operates in a manner consistent with charitable purposes and does not engage in activities that could jeopardize its tax-exempt status, periodic reviews shall be conducted. The periodic reviews shall, at a minimum, include the following subjects:
+
+(a) Whether compensation arrangements and benefits are reasonable, based on competent survey information, and the result of arm’s-length bargaining.
+
+(b) Whether partnerships, joint ventures, and arrangements with management organizations conform to the corporation’s written policies, are properly recorded, reflect reasonable investment or payments for goods and services, further charitable purposes, and do not result in inurement, impermissible private benefit, or in an excess benefit transaction.
+
+### SECTION 8. USE OF OUTSIDE EXPERTS ###
+
+When conducting the periodic reviews as provided for in Section 7, the corporation may, but need not, use outside advisors. If outside experts are used, their use shall not relieve the governing board of its responsibility for ensuring periodic reviews are conducted.
+
+## ARTICLE 10 - AMENDMENT OF BYLAWS ##
+
+### SECTION 1. AMENDMENT ###
+
+Subject to any provision of law applicable to the amendment of bylaws of public benefit nonprofit corporations, these bylaws, or any of them, may be altered, amended, or repealed and new bylaws adopted as follows:
+
+(a) Subject to the power of members, if any, to change or repeal these bylaws under Section 5150 of the Corporations Code, by approval of the board of directors unless the bylaw amendment would materially and adversely affect the rights of members, if any, as to voting or transfer, provided, however, if this corporation has admitted any members, then a bylaw specifying or changing the fixed number of directors of the corporation, the maximum or minimum number of directors, or changing from a fixed to variable board or vice versa, may not be adopted, amended, or repealed except as provided in subparagraph (b) of this Section; or
+
+(b) By approval of the members, if any, of this corporation.
+
+## ARTICLE 11 - AMENDMENT OF ARTICLES ##
+
+### SECTION 1. AMENDMENT OF ARTICLES BEFORE ADMISSION OF MEMBERS ###
+
+Before any members have been admitted to the corporation, any amendment of the articles of incorporation may be adopted by approval of the board of directors.
+
+### SECTION 2. AMENDMENT OF ARTICLES AFTER ADMISSION OF MEMBERS ###
+
+After members, if any, have been admitted to the corporation, amendment of the articles of incorporation may be adopted by the approval of the board of directors and by the approval of the members of this corporation.
+
+### SECTION 3. CERTAIN AMENDMENTS ###
+
+Notwithstanding the above sections of this Article, this corporation shall not amend its articles of incorporation to alter any statement which appears in the original articles of incorporation of the names and addresses of the first directors of this corporation, nor the name and address of its initial agent, except to correct an error in such statement or to delete such statement after the corporation has filed a “Statement by a Domestic Nonprofit Corporation” pursuant to Section 6210 of the California Nonprofit Corporation Law.
+
+## ARTICLE 12 - PROHIBITION AGAINST SHARING CORPORATE PROFITS AND ASSETS ##
+
+### SECTION 1. PROHIBITION AGAINST SHARING CORPORATE PROFITS AND ASSETS ###
+
+No member, director, officer, employee, or other person connected with this corporation, or any private individual, shall receive at any time any of the net earnings or pecuniary profit from the operations of the corporation, provided, however, that this provision shall not prevent payment to any such person of reasonable compensation for services performed for the corporation in effecting any of its public or charitable purposes, provided that such compensation is otherwise permitted by these bylaws and is fixed by resolution of the board of directors; and no such person or persons shall be entitled to share in the distribution of, and shall not receive, any of the corporate assets on dissolution of the corporation. All members, if any, of the corporation shall be deemed to have expressly consented and agreed that on such dissolution or winding up of the affairs of the corporation, whether voluntarily or involuntarily, the assets of the corporation, after all debts have been satisfied, shall be distributed as required by the articles of incorporation of this corporation and not otherwise.
+
+## ARTICLE 13 - MEMBERS ##
+
+### SECTION 1. DETERMINATION OF MEMBERS ###
+
+If this corporation makes no provision for members, then, pursuant to Section 5310(b) of the Nonprofit Public Benefit Corporation Law of the State of California, any action which would otherwise, under law or the provisions of the articles of incorporation or bylaws of this corporation, require approval by a majority of all members or approval by the members, shall only require the approval of the board of directors.
+
+## ARTICLE 14 - SHAREHOLDERS ##
+
+The corporation has issued no shares of stock, and has no shareholders.
+
+
+
+## WRITTEN CONSENT OF DIRECTORS ADOPTING BYLAWS ##
+
+We, the undersigned, are all of the persons acting as the initial directors of Django Events Foundation North America, a California nonprofit corporation, and, pursuant to the authority granted to the directors by these bylaws to take action by unanimous written consent without a meeting, consent to, and hereby do, adopt the foregoing bylaws, consisting of 35 pages, as the bylaws of this corporation.
+
+Dated: Jan 2, 2019
+
+
+Jeffrey Triplett, Director
+
+Monique Murphy, Director
+
+Katia Lira, Director
+
+Adam Fast, Director	
+
+Katherine Michel, Director
+
+Josue Balandrano Coronel, Director
+
+
+## CERTIFICATE ##
+
+This is to certify that the foregoing is a true and correct copy of the bylaws of the corporation named in the title thereto and that such bylaws were duly adopted by the board of directors of said corporation on the date set forth below.
+
+Dated: Jan 2, 2019
+
+Katherine Michel, Secretary


### PR DESCRIPTION
Our blog doesn't actually have announcements, I believe Josue Katia and I all started in 2018, so the dates of board members should be checked to make sure I'm right.

We also might want to separate offices from board seats as far as dates go - with officers significantly changing the dates of board service look like the dates they were an officer. Maybe we separate out the offices and show year by year?